### PR TITLE
Merge supplied headers over default headers rather than replace them

### DIFF
--- a/lib/atum/link.rb
+++ b/lib/atum/link.rb
@@ -37,7 +37,7 @@ module Atum
     def run(*parameters)
       options = parameters.pop
       raise ArgumentError, 'options must be a hash' unless options.is_a?(Hash)
-      options = { headers: @headers }.merge(options)
+      options[:headers] = @headers.merge(options.fetch(:headers, {}))
 
       options[:body] = parameters.pop if @link_schema.needs_request_body?
 


### PR DESCRIPTION
That. @isaacseymour @petehamilton perhaps you could review. I've tested locally with `gocardless` supplying a PDF override header.
