### PR TITLE
Allow the underlying http adapter to be specified for tests

### DIFF
--- a/lib/atum/core/link.rb
+++ b/lib/atum/core/link.rb
@@ -18,9 +18,16 @@ module Atum
       #   include:
       #   - default_headers: Optionally, a set of headers to include in every
       #     request made by the client.  Default is no custom headers.
+      #   - http_adapter: Optionally, the http adapter to use; for now we accept
+      #     adapters according to Faraday's builder:
+      #     https://github.com/lostisland/faraday/blob/v0.8.9/lib/faraday/builder.rb
+      #     e.g. http_adapter: [:rack, Rails.application]
       def initialize(url, link_schema, options = {})
         root_url, @path_prefix = unpack_url(url)
-        @connection = Faraday.new(url: root_url)
+        http_adapter = options[:http_adapter] || [:net_http]
+        @connection = Faraday.new(url: root_url) do |faraday|
+          faraday.adapter(*http_adapter)
+        end
         @link_schema = link_schema
         @headers = options[:default_headers] || {}
       end

--- a/spec/integration/client_integration_spec.rb
+++ b/spec/integration/client_integration_spec.rb
@@ -117,4 +117,18 @@ describe 'The Generated Client' do
       expect(Fruity::VERSION).to eq(version)
     end
   end
+
+  context 'when using a :test http_adapter' do
+    before do
+      stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get("#{url}/lemon") { |_| [200, {}, 5] }
+      end
+      Fruity.connect(url, 'USER', 'PASSWORD',
+                     http_adapter: [:test, stubs])
+    end
+
+    it 'uses the defined stubs' do
+      expect(Fruity.lemon.list).to eq(5)
+    end
+  end
 end


### PR DESCRIPTION
Example usage:

``` ruby
    GoCardless::Enterprise.connect('http://dummy/enterprise/',api_key.id,api_key.key,
                                   http_adapter: [:rack, Rails.application] 
                                  )
```

@isaacseymour @petehamilton

This is clearly Faraday specific at the moment. That's probably fine for now, but I know you've done a good job of abstracting the HTTP client in use. 

My gut feeling is we won't need to worry overly about this now - we can abstract the `http_adapter` option bit at a later stage, in much the same way that the Faraday folks have abstracted the various adapters they use over time.

Thoughts?
