### PR TITLE
Encode href params before substituting them into the url

### DIFF
--- a/lib/atum/core/schema/link_schema.rb
+++ b/lib/atum/core/schema/link_schema.rb
@@ -58,6 +58,8 @@ module Atum
                                  "for #{expected_params.count}"
           end
 
+          params.map! { |param| URI.escape(param) }
+
           href.gsub(PARAMETER_REGEX) { |_match| format_parameter(params.shift) }
         end
 

--- a/spec/atum/core/schema/link_schema_spec.rb
+++ b/spec/atum/core/schema/link_schema_spec.rb
@@ -83,6 +83,11 @@ describe Atum::Core::Schema::LinkSchema do
       it { is_expected.to raise_error(ArgumentError) }
     end
 
+    it 'URL encodes href params' do
+      expect(update.construct_path('MD00006N30R4F0>'))
+        .to eq('/resource/MD00006N30R4F0%3E')
+    end
+
     it 'returns relative url' do
       expect(update.construct_path('4472831-bf66-4bc2-865f-e2c4c2b14c78'))
         .to eq('/resource/4472831-bf66-4bc2-865f-e2c4c2b14c78')


### PR DESCRIPTION
@greysteil This fixes https://exceptions.gocardless.com/production/gocardless-live/group/5303/

Review?

Next steps:
1. Bump Atum
2. Update Atum dependency in GCER
