### PR TITLE
Fix raw ApiError raises by providing a default message

### DIFF
--- a/lib/atum/core/response.rb
+++ b/lib/atum/core/response.rb
@@ -46,7 +46,13 @@ module Atum
       end
 
       def handle_raw
-        error? ? raise(ApiError) : raw_body
+        default_raw_message = {
+          "message" => "Something went wrong with this raw request\n" +
+          "status: #{@response.status}\n" +
+          "headers: #{@response.headers}\n" +
+          "body: #{@response.body}"
+        }
+        error? ? raise(ApiError, default_raw_message) : raw_body
       end
     end
   end

--- a/spec/atum/core/response_spec.rb
+++ b/spec/atum/core/response_spec.rb
@@ -28,6 +28,17 @@ describe Atum::Core::Response do
       it 'should come through raw' do
         expect(body).to eq(response_body)
       end
+
+      context 'when the response is an error' do
+        let(:response) do
+          double(headers: { 'Content-Type' => 'application/text' },
+                 body: 'FOOBARBAZ', status: 400)
+        end
+
+        it "should raise an error" do
+          expect { api_response.body }.to raise_error(Atum::Core::ApiError)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
@petehamilton review? The rubocops that failed on Circle seem to have been there for a while.
