### PR TITLE
Default header: preserve options

### DIFF
--- a/lib/atum/generation/generators/views/module.erb
+++ b/lib/atum/generation/generators/views/module.erb
@@ -72,13 +72,16 @@ module <%= @module_name %>
   def self.default_options
     {
       default_headers: {
-        <%= @default_headers.merge(
-            'User-Agent' => '#{user_agent}',
-            'Content-Type' => 'application/json'
-          ).map do |k, v|
+      <%=
+        {
+          'User-Agent' => '#{user_agent}',
+          'Content-Type' => 'application/json'
+        }.merge(@default_headers).map do |k, v|
           "\"#{k.to_s}\" => \"#{v.to_s}\""
-        end.join(",\n        ") %>
-    } }
+        end.join(",\n        ")
+      %>
+      }
+    }
   end
 
   def self.user_agent


### PR DESCRIPTION
It wasn't possible to override 'Content-Type' using `merge`. Simplest
solution was to switch to `reverse_merge` since ActiveSupport is
required anyway.
